### PR TITLE
Add nitter.cf as a public instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A privacy-focused Twitter/X frontend written in Rust.
 
+## Public instances
+
+- [teapot.amaanq.com](https://teapot.amaanq.com) - A demo instance I have deployed
+  (not intended for mass traffic)
+- [nitter.cf](https://nitter.cf) - public instance (backup: [xitter.cf](https://xitter.cf))
+
 ## Features
 
 - **Privacy-focused**: No third-party JavaScript, tracking, ads, or remote fonts


### PR DESCRIPTION
## Summary
- Adds a Public instances section listing a working deployment of this source: [nitter.cf](https://nitter.cf)
- Backup domain: [xitter.cf](https://xitter.cf)

## Test plan
- [x] https://nitter.cf returns 200
- [x] https://xitter.cf returns 200
- Open either URL and load a profile or search


Made with [Cursor](https://cursor.com)